### PR TITLE
Fixed relative refs & jquery cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HS item from the API and displays it.
 
 ## Demo
 
-[index.html](http://ausftas.github.io/example-api-tariffs/)
+[index.html](http://markmuir87.github.io/example-api-tariffs/)
 
 
 ## Additional Documentation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HS item from the API and displays it.
 
 ## Demo
 
-[index.html](http://markmuir87.github.io/example-api-tariffs/)
+[index.html](http://ausftas.github.io/example-api-tariffs/)
 
 
 ## Additional Documentation

--- a/common.js
+++ b/common.js
@@ -1,0 +1,16 @@
+"use strict";
+(function($)
+{
+  var api_prefix = 'https://ftaportal.dfat.gov.au/api/v1/json';
+  $.invoke = function(url, callback)
+  {
+    $.getJSON(api_prefix + url).done(function(data)
+    {
+      if (data.deprecated)
+      {
+        console.error(data.deprecated);
+      }
+      callback(data.results);
+    });
+  };
+}(jQuery));

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="http://blog.dfilimonov.com/github-ribbons-css/ribbons.css">
   <script src="../example-api-common/style.js"></script>
   <!-- shared sources -->
-  <script src="../example-api-common/common.js"></script>
+  <script src="common.js"></script>
 </head>
 <body>
   <div id="header"></div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Tariffs Example</title>
   <meta charset="UTF-8">
-  <script src="https://code.jquery.com/jquery-2.2.0.min.js"></script>
+  <script src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.2.0.min.js"></script>
   <!-- look and feel -->
   <link rel="stylesheet" type="text/css" href="../example-api-common/style.css">
   <link rel="stylesheet" type="text/css" href="http://blog.dfilimonov.com/github-ribbons-css/ribbons.css">


### PR DESCRIPTION
Hey, nice work on the API!

I've fixed the reference to 'common.js' (and copy pasted it in), and have also changed the jquery cdn link to the Microsoft cdn, as the original was 404'ing.

The example is now functional but not pretty because the 'style' js and css files are still missing.